### PR TITLE
Removes jazzy from install steps when deploying new versions

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -68,8 +68,6 @@ jobs:
           ref: main
       - name: Install sourcekitten
         run: brew install sourcekitten
-      - name: Install jazzy
-        run: gem install jazzy
       - name: Generate documentation
         run: ./.github/document.sh
       - uses: JamesIves/github-pages-deploy-action@4.1.3


### PR DESCRIPTION
Because https://github.com/actions/virtual-environments/issues/4320 has merged and deployed, we should no longer need to gem install jazzy before generating documents.  This should decrease our document deployment time by ~4 minutes.
## Checklist:
- [x] Did you sign the [Contributor License Agreement](https://cla-assistant.io/wwt/SwiftCurrent)?
- [ ] Is the linter reporting 0 errors?
- [ ] Does the CI pipeline pass?