### PR TITLE
Preview Providers now compile correctly

### DIFF
--- a/Sources/SwiftCurrent_SwiftUI/Extensions/ThenProceedExtensions.swift
+++ b/Sources/SwiftCurrent_SwiftUI/Extensions/ThenProceedExtensions.swift
@@ -24,6 +24,8 @@ private func verifyWorkflowIsWellFormed<LHS: FlowRepresentable, RHS: FlowReprese
  Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
  - Parameter with: a `FlowRepresentable` type that should be presented.
  - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
+ - NOTE: Should be called inside a `WorkflowLauncher` initializer.
+ - IMPORTANT: Not for use in UIKit, unless you're doing SwiftUI interop.
  */
 @available(iOS 14.0, macOS 11, tvOS 14.0, watchOS 7.0, *)
 public func thenProceed<FR: FlowRepresentable & View>(with: FR.Type) -> WorkflowItem<FR, Never, FR> {
@@ -35,6 +37,8 @@ public func thenProceed<FR: FlowRepresentable & View>(with: FR.Type) -> Workflow
  - Parameter with: a `FlowRepresentable` type that should be presented.
  - Parameter nextItem: a closure returning the next item in the `Workflow`.
  - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
+ - NOTE: Should be called inside a `WorkflowLauncher` initializer.
+ - IMPORTANT: Not for use in UIKit, unless you're doing SwiftUI interop.
  */
 @available(iOS 14.0, macOS 11, tvOS 14.0, watchOS 7.0, *)
 public func thenProceed<FR: FlowRepresentable & View, F, W, C>(with: FR.Type, nextItem: () -> WorkflowItem<F, W, C>) -> WorkflowItem<FR, WorkflowItem<F, W, C>, FR> {
@@ -47,6 +51,8 @@ public func thenProceed<FR: FlowRepresentable & View, F, W, C>(with: FR.Type, ne
  Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
  - Parameter with: a `FlowRepresentable` type that should be presented.
  - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
+ - NOTE: Should be called inside a `WorkflowLauncher` initializer.
+ - IMPORTANT: Not for use in UIKit, unless you're doing SwiftUI interop.
  */
 @available(iOS 14.0, macOS 11, tvOS 14.0, *)
 public func thenProceed<VC: FlowRepresentable & UIViewController>(with: VC.Type) -> WorkflowItem<ViewControllerWrapper<VC>, Never, ViewControllerWrapper<VC>> {
@@ -58,6 +64,8 @@ public func thenProceed<VC: FlowRepresentable & UIViewController>(with: VC.Type)
  - Parameter with: a `FlowRepresentable` type that should be presented.
  - Parameter nextItem: a closure returning the next item in the `Workflow`.
  - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
+ - NOTE: Should be called inside a `WorkflowLauncher` initializer.
+ - IMPORTANT: Not for use in UIKit, unless you're doing SwiftUI interop.
  */
 @available(iOS 14.0, macOS 11, tvOS 14.0, *)
 public func thenProceed<VC: FlowRepresentable & UIViewController, F, W, C>(with: VC.Type, nextItem: () -> WorkflowItem<F, W, C>) -> WorkflowItem<ViewControllerWrapper<VC>, WorkflowItem<F, W, C>, ViewControllerWrapper<VC>> {

--- a/Sources/SwiftCurrent_SwiftUI/Extensions/ThenProceedExtensions.swift
+++ b/Sources/SwiftCurrent_SwiftUI/Extensions/ThenProceedExtensions.swift
@@ -1,4 +1,3 @@
-//  swiftlint:disable:this file_name
 //  ThenProceedExtensions.swift
 //  SwiftCurrent_SwiftUI
 //

--- a/Sources/SwiftCurrent_SwiftUI/Extensions/ThenProceedExtensions.swift
+++ b/Sources/SwiftCurrent_SwiftUI/Extensions/ThenProceedExtensions.swift
@@ -20,143 +20,48 @@ private func verifyWorkflowIsWellFormed<LHS: FlowRepresentable, RHS: FlowReprese
     assert(LHS.WorkflowOutput.self is RHS.WorkflowInput.Type, "Workflow is malformed, expected output of: \(LHS.self) (\(LHS.WorkflowOutput.self)) to match input of: \(RHS.self) (\(RHS.WorkflowInput.self)")
 }
 
+/**
+ Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
+ - Parameter with: a `FlowRepresentable` type that should be presented.
+ - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
+ */
 @available(iOS 14.0, macOS 11, tvOS 14.0, watchOS 7.0, *)
-extension View {
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    public func thenProceed<FR: FlowRepresentable & View>(with: FR.Type) -> WorkflowItem<FR, Never, FR> {
-        WorkflowItem(FR.self)
-    }
-
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Parameter nextItem: a closure returning the next item in the `Workflow`.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    public func thenProceed<FR: FlowRepresentable & View, F, W, C>(with: FR.Type, nextItem: () -> WorkflowItem<F, W, C>) -> WorkflowItem<FR, WorkflowItem<F, W, C>, FR> {
-        verifyWorkflowIsWellFormed(FR.self, F.self)
-        return WorkflowItem(FR.self) { nextItem() }
-    }
-
-    #if (os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)) && canImport(UIKit)
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    @available(iOS 14.0, macOS 11, tvOS 14.0, *)
-    public func thenProceed<VC: FlowRepresentable & UIViewController>(with: VC.Type) -> WorkflowItem<ViewControllerWrapper<VC>, Never, ViewControllerWrapper<VC>> {
-        WorkflowItem(VC.self)
-    }
-
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Parameter nextItem: a closure returning the next item in the `Workflow`.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    @available(iOS 14.0, macOS 11, tvOS 14.0, *)
-    public func thenProceed<VC: FlowRepresentable & UIViewController, F, W, C>(with: VC.Type, nextItem: () -> WorkflowItem<F, W, C>) -> WorkflowItem<ViewControllerWrapper<VC>, WorkflowItem<F, W, C>, ViewControllerWrapper<VC>> {
-        verifyWorkflowIsWellFormed(VC.self, F.self)
-        return WorkflowItem(VC.self) { nextItem() }
-    }
-    #endif
+public func thenProceed<FR: FlowRepresentable & View>(with: FR.Type) -> WorkflowItem<FR, Never, FR> {
+    WorkflowItem(FR.self)
 }
 
+/**
+ Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
+ - Parameter with: a `FlowRepresentable` type that should be presented.
+ - Parameter nextItem: a closure returning the next item in the `Workflow`.
+ - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
+ */
 @available(iOS 14.0, macOS 11, tvOS 14.0, watchOS 7.0, *)
-extension App {
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    public func thenProceed<FR: FlowRepresentable & View>(with: FR.Type) -> WorkflowItem<FR, Never, FR> {
-        WorkflowItem(FR.self)
-    }
-
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Parameter nextItem: a closure returning the next item in the `Workflow`.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    public func thenProceed<FR: FlowRepresentable & View, F, W, C>(with: FR.Type, nextItem: () -> WorkflowItem<F, W, C>) -> WorkflowItem<FR, WorkflowItem<F, W, C>, FR> {
-        verifyWorkflowIsWellFormed(FR.self, F.self)
-        return WorkflowItem(FR.self) { nextItem() }
-    }
-
-    #if (os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)) && canImport(UIKit)
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    @available(iOS 14.0, macOS 11, tvOS 14.0, *)
-    public func thenProceed<VC: FlowRepresentable & UIViewController>(with: VC.Type) -> WorkflowItem<ViewControllerWrapper<VC>, Never, ViewControllerWrapper<VC>> {
-        WorkflowItem(VC.self)
-    }
-
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Parameter nextItem: a closure returning the next item in the `Workflow`.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    @available(iOS 14.0, macOS 11, tvOS 14.0, *)
-    public func thenProceed<VC: FlowRepresentable & UIViewController, F, W, C>(with: VC.Type, nextItem: () -> WorkflowItem<F, W, C>) -> WorkflowItem<ViewControllerWrapper<VC>, WorkflowItem<F, W, C>, ViewControllerWrapper<VC>> {
-        verifyWorkflowIsWellFormed(VC.self, F.self)
-        return WorkflowItem(VC.self) { nextItem() }
-    }
-    #endif
+public func thenProceed<FR: FlowRepresentable & View, F, W, C>(with: FR.Type, nextItem: () -> WorkflowItem<F, W, C>) -> WorkflowItem<FR, WorkflowItem<F, W, C>, FR> {
+    verifyWorkflowIsWellFormed(FR.self, F.self)
+    return WorkflowItem(FR.self) { nextItem() }
 }
 
-@available(iOS 14.0, macOS 11, tvOS 14.0, watchOS 7.0, *)
-extension Scene {
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    public func thenProceed<FR: FlowRepresentable & View>(with: FR.Type) -> WorkflowItem<FR, Never, FR> {
-        WorkflowItem(FR.self)
-    }
-
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Parameter nextItem: a closure returning the next item in the `Workflow`.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    public func thenProceed<FR: FlowRepresentable & View, F, W, C>(with: FR.Type, nextItem: () -> WorkflowItem<F, W, C>) -> WorkflowItem<FR, WorkflowItem<F, W, C>, FR> {
-        verifyWorkflowIsWellFormed(FR.self, F.self)
-        return WorkflowItem(FR.self) { nextItem() }
-    }
-
-    #if (os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)) && canImport(UIKit)
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    @available(iOS 14.0, macOS 11, tvOS 14.0, *)
-    public func thenProceed<VC: FlowRepresentable & UIViewController>(with: VC.Type) -> WorkflowItem<ViewControllerWrapper<VC>, Never, ViewControllerWrapper<VC>> {
-        WorkflowItem(VC.self)
-    }
-
-    /**
-     Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
-     - Parameter with: a `FlowRepresentable` type that should be presented.
-     - Parameter nextItem: a closure returning the next item in the `Workflow`.
-     - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
-     */
-    @available(iOS 14.0, macOS 11, tvOS 14.0, *)
-    public func thenProceed<VC: FlowRepresentable & UIViewController, F, W, C>(with: VC.Type, nextItem: () -> WorkflowItem<F, W, C>) -> WorkflowItem<ViewControllerWrapper<VC>, WorkflowItem<F, W, C>, ViewControllerWrapper<VC>> {
-        verifyWorkflowIsWellFormed(VC.self, F.self)
-        return WorkflowItem(VC.self) { nextItem() }
-    }
-    #endif
+#if (os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)) && canImport(UIKit)
+/**
+ Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
+ - Parameter with: a `FlowRepresentable` type that should be presented.
+ - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
+ */
+@available(iOS 14.0, macOS 11, tvOS 14.0, *)
+public func thenProceed<VC: FlowRepresentable & UIViewController>(with: VC.Type) -> WorkflowItem<ViewControllerWrapper<VC>, Never, ViewControllerWrapper<VC>> {
+    WorkflowItem(VC.self)
 }
+
+/**
+ Adds an item to the workflow; enforces the `FlowRepresentable.WorkflowOutput` of the previous item matches the args that will be passed forward.
+ - Parameter with: a `FlowRepresentable` type that should be presented.
+ - Parameter nextItem: a closure returning the next item in the `Workflow`.
+ - Returns: a new `WorkflowItem` with the additional `FlowRepresentable` item.
+ */
+@available(iOS 14.0, macOS 11, tvOS 14.0, *)
+public func thenProceed<VC: FlowRepresentable & UIViewController, F, W, C>(with: VC.Type, nextItem: () -> WorkflowItem<F, W, C>) -> WorkflowItem<ViewControllerWrapper<VC>, WorkflowItem<F, W, C>, ViewControllerWrapper<VC>> {
+    verifyWorkflowIsWellFormed(VC.self, F.self)
+    return WorkflowItem(VC.self) { nextItem() }
+}
+#endif

--- a/Tests/SwiftCurrent_SwiftUITests/GenericConstraintTests.swift
+++ b/Tests/SwiftCurrent_SwiftUITests/GenericConstraintTests.swift
@@ -1886,8 +1886,8 @@ final class GenericConstraintTests: XCTestCase, View {
 
         try XCTAssertThrowsFatalError {
             _ = WorkflowLauncher(isLaunched: .constant(true)) {
-                self.thenProceed(with: FR0.self) {
-                    self.thenProceed(with: FR1.self).persistence(.removedAfterProceeding)
+                thenProceed(with: FR0.self) {
+                    thenProceed(with: FR1.self).persistence(.removedAfterProceeding)
                 }
             }
         }

--- a/Tests/SwiftCurrent_SwiftUITests/SwiftCurrent_SwiftUITests.swift
+++ b/Tests/SwiftCurrent_SwiftUITests/SwiftCurrent_SwiftUITests.swift
@@ -731,6 +731,27 @@ final class SwiftCurrent_SwiftUIConsumerTests: XCTestCase, App {
 
         wait(for: [exp], timeout: TestConstant.timeout)
     }
+
+    func testWorkflowCompilesWithPreviewProvider() throws {
+        struct FR1: View, FlowRepresentable, Inspectable {
+            var _workflowPointer: AnyFlowRepresentable?
+            var body: some View { Text("FR1 type") }
+        }
+        struct FR2: View, FlowRepresentable, Inspectable {
+            var _workflowPointer: AnyFlowRepresentable?
+            var body: some View { Text("FR2 type") }
+        }
+
+        struct FR1_Previews: PreviewProvider {
+            static var previews: some View {
+                WorkflowLauncher(isLaunched: .constant(true)) {
+                    thenProceed(with: FR1.self) {
+                        thenProceed(with: FR2.self)
+                    }
+                }
+            }
+        }
+    }
 }
 
 @available(iOS 14.0, macOS 11, tvOS 14.0, watchOS 7.0, *)


### PR DESCRIPTION
<!-- All PRs should have some kind of issue backing them. This means the community has had some opportunity to contribute ideas, or that the PR is fixing a problem that is being tracked -->
### Linked Issue: Closes #156 

<!-- (See our contributing guidelines for more details) -->

<!-- Please remove any items below that may not apply to your Pull Request -->
## Checklist:
- [x] Did you sign the [Contributor License Agreement](https://cla-assistant.io/wwt/SwiftCurrent)?
- [x] Is the linter reporting 0 errors?
- [x] Did you comply with our [styleguide](https://github.com/wwt/SwiftCurrent/blob/main/.github/STYLEGUIDE.md)?
- [x] Is there [adequate test coverage](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#test-etiquette) for your new code?
- [x] Does the CI pipeline pass?
- [x] Did you [update the documentation](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#documentation)?
- [x] Did you [change the public API](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#public-api)?
- [x] Have you done everything you can to make sure that errors that can occur are compile-time errors, and if they have to be runtime do you have adequate tests and documentation around those runtime errors? [For more details](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#errors).

----

### If Public API Has Changed:
- [ ] Did you deprecate (rather than remove) any old methods/variables/etc? [Our philosophy for deprecation](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#deprecation).
- [x] Have you done the best that you can to make sure that the compiler guides people to changing to the new API? (Example: the renamed attribute)
- [x] If necessary, have you tested the upgrade path for at least N-1 versions? For example, if data persists between v1 and v2 then that upgrade should be tested and as easy as we can make it.
