### PR TITLE
Implements eraseToAnyWorkflow function on Workflow.

### DIFF
--- a/Sources/SwiftCurrent/Models/Workflow.swift
+++ b/Sources/SwiftCurrent/Models/Workflow.swift
@@ -522,6 +522,10 @@ extension Workflow {
 }
 
 extension Workflow {
+    /**
+     Wraps this workflow with a type eraser.
+     - Returns: an ``AnyWorkflow`` wrapping this ``Workflow``
+     */
     public func eraseToAnyWorkflow() -> AnyWorkflow {
         AnyWorkflow(self)
     }

--- a/Sources/SwiftCurrent/Models/Workflow.swift
+++ b/Sources/SwiftCurrent/Models/Workflow.swift
@@ -520,3 +520,9 @@ extension Workflow {
         return wf
     }
 }
+
+extension Workflow {
+    public func eraseToAnyWorkflow() -> AnyWorkflow {
+        AnyWorkflow(self)
+    }
+}

--- a/Tests/SwiftCurrentTests/WorkflowConsumerTests.swift
+++ b/Tests/SwiftCurrentTests/WorkflowConsumerTests.swift
@@ -223,6 +223,30 @@ class WorkflowConsumerTests: XCTestCase {
                       args: 1)
         }
     }
+    
+    func testWorkflowCanEraseToAnyWorkflow() {
+        struct FR1: FlowRepresentable {
+            var _workflowPointer: AnyFlowRepresentable?
+        }
+        
+        struct FR2: FlowRepresentable {
+            var _workflowPointer: AnyFlowRepresentable?
+        }
+        
+        struct FR3: FlowRepresentable {
+            var _workflowPointer: AnyFlowRepresentable?
+        }
+        
+        let wf = Workflow(FR1.self)
+            .thenProceed(with: FR2.self)
+            .thenProceed(with: FR3.self)
+        
+        let anyWF = wf.eraseToAnyWorkflow()
+        
+        wf.forEach {
+            XCTAssertIdentical($0.value, anyWF.first?.traverse($0.position)?.value)
+        }
+    }
 }
 
 extension WorkflowConsumerTests {


### PR DESCRIPTION
<!-- All PRs should have some kind of issue backing them. This means the community has had some opportunity to contribute ideas, or that the PR is fixing a problem that is being tracked -->
### Linked Issue: Closes #105 

<!-- (See our contributing guidelines for more details) -->

<!-- Please remove any items below that may not apply to your Pull Request -->
## Checklist:
- [x] Did you sign the [Contributor License Agreement](https://cla-assistant.io/wwt/SwiftCurrent)?
- [x] Is the linter reporting 0 errors?
- [x] Did you comply with our [styleguide](https://github.com/wwt/SwiftCurrent/blob/main/.github/STYLEGUIDE.md)?
- [x] Is there [adequate test coverage](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#test-etiquette) for your new code?
- [x] Does the CI pipeline pass?
- [x] Did you [update the documentation](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#documentation)?
- [x] Did you [change the public API](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#public-api)?
- [x] Have you done everything you can to make sure that errors that can occur are compile-time errors, and if they have to be runtime do you have adequate tests and documentation around those runtime errors? [For more details](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#errors).