### PR TITLE
Removes Richard Gist as point of contact from Code of Conduct and replaces with Matt Hartfield.

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at Richard.Gist@wwt.com or Tyler.Thompson@wwt.com.
+reported by contacting the project team at Tyler.Thompson@wwt.com or Matt.Hartfield@wwt.com.
 All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
<!-- All PRs should have some kind of issue backing them. This means the community has had some opportunity to contribute ideas, or that the PR is fixing a problem that is being tracked -->

<!-- (See our contributing guidelines for more details) -->

<!-- Please remove any items below that may not apply to your Pull Request -->
## Checklist:
- [x] Did you sign the [Contributor License Agreement](https://cla-assistant.io/wwt/SwiftCurrent)?
- [x] Did you [update the documentation](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#documentation)?
