### PR TITLE
Fixes an issue where holding self weakly is causing a memory leak when calling workflow.abandon

### DIFF
--- a/Sources/SwiftCurrent_UIKit/Extensions/WorkflowUIKitAdditions.swift
+++ b/Sources/SwiftCurrent_UIKit/Extensions/WorkflowUIKitAdditions.swift
@@ -32,8 +32,8 @@ extension AnyWorkflow {
      */
     public func abandon(animated: Bool = true, onFinish:(() -> Void)? = nil) {
         if let presenter = orchestrationResponder as? UIKitPresenter {
-            presenter.abandon(self, animated: animated) { [weak self] in
-                self?._abandon()
+            presenter.abandon(self, animated: animated) { [self] in
+                self._abandon()
                 onFinish?()
             }
         } else if let responder = orchestrationResponder {


### PR DESCRIPTION
## Abstract

There was an issue where calling `workflow.abandon` in the `onFinish` completion handler of a launched workflow could fail to be called because the `workflow` had already been deallocated. This caused ViewControllers to remain allocated. This issue did not occur when the workflow was abandoned within the workflow, but did reliably occur when trying to clean up when finishing.

By making this a strong reference, we can see in the memory graph that the ViewControllers are being reliably deallocated. I attached a video of me doing just this. Starting with the current code and showing all of the ViewControllers still in memory and then re-running with the strong reference showing all of the ViewControllers no longer in memory.

## Video

[video showing memory graph debugging](https://player.vimeo.com/video/685903215?h=cae98fecc2)

<!-- All PRs should have some kind of issue backing them. This means the community has had some opportunity to contribute ideas, or that the PR is fixing a problem that is being tracked -->
### Linked Issue: Closes #41 

<!-- (See our contributing guidelines for more details) -->

<!-- Please remove any items below that may not apply to your Pull Request -->
## Checklist:
- [x] Did you sign the [Contributor License Agreement](https://cla-assistant.io/wwt/SwiftCurrent)?
- [x] Is the linter reporting 0 errors?
- [x] Did you comply with our [styleguide](https://github.com/wwt/SwiftCurrent/blob/main/.github/STYLEGUIDE.md)?
- [x] Is there [adequate test coverage](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#test-etiquette) for your new code?
- [x] Does the CI pipeline pass?