### PR TITLE
Updates codecov action version in pipeline.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
         run: bundle exec fastlane unit_test
         working-directory: ${{ env.working-directory }}
       - name: Codecov
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v3.0.0
         with:
           fail_ci_if_error: true
       - name: Upload Test logs

--- a/.github/workflows/PR_CI.yml
+++ b/.github/workflows/PR_CI.yml
@@ -14,7 +14,7 @@ jobs:
         run: bundle exec fastlane unit_test
         working-directory: ${{ env.working-directory }}
       - name: Codecov
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v3.0.0
         with:
           fail_ci_if_error: true
       - name: Upload Test logs

--- a/.github/workflows/PR_CI.yml
+++ b/.github/workflows/PR_CI.yml
@@ -1,6 +1,6 @@
 name: PR_CI
 
-on: [ pull_request ]
+on: [ pull_request, workflow_dispatch ]
 
 jobs:
   test:


### PR DESCRIPTION
<!-- Please remove any items below that may not apply to your Pull Request -->
## Checklist:
- [x] Did you sign the [Contributor License Agreement](https://cla-assistant.io/wwt/SwiftCurrent)?
- [x] Is the linter reporting 0 errors?
- [x] Does the CI pipeline pass?


Looks like codecov's GitHub action has a new uploader and has sunset the v1 uploader. I bumped the version a bit higher to 3.0 due to some bug fixes added in between versions 2 and 3.

https://github.com/codecov/codecov-action/releases/tag/v2.0.0

> "On February 1, 2022, the v1 [uploader](https://github.com/codecov/uploader) will be full sunset and no longer function. This is due
to the deprecation of the underlying bash uploader. This version uses the new uploader."