### PR TITLE
Add variation of XCTAssertWorkflowLaunched for use with AnyWorkflow

### DIFF
--- a/Sources/SwiftCurrent_Testing/CustomAssertions.swift
+++ b/Sources/SwiftCurrent_Testing/CustomAssertions.swift
@@ -23,11 +23,12 @@ public func XCTAssertWorkflowLaunched<F>(from VC: UIViewController, workflow: Wo
 
 /// Assert that a workflow was launched and matches the workflow passed in
 public func XCTAssertWorkflowLaunched(from VC: UIViewController, workflow: AnyWorkflow?, file: StaticString = #filePath, line: UInt = #line) {
-    let last = VC.launchedWorkflows.last
     guard let workflow = workflow else {
-        XCTAssertNil(last, "workflow found when none expected", file: file, line: line)
+        XCTAssertNoWorkflowLaunched(from: VC, file: file, line: line)
         return
     }
+
+    let last = VC.launchedWorkflows.last
     XCTAssertNotNil(last, "No workflow found", file: file, line: line)
     guard let listenerWorkflow = last,
           listenerWorkflow.count == workflow.count else {
@@ -44,6 +45,11 @@ public func XCTAssertWorkflowLaunched(from VC: UIViewController, workflow: AnyWo
         let expected = workflowNode.value.metadata.flowRepresentableTypeDescriptor
         XCTAssert(actual == expected, "Expected type: \(expected), but got: \(actual)", file: file, line: line)
     }
+}
+
+/// Assert that no workflow was launched
+public func XCTAssertNoWorkflowLaunched(from VC: UIViewController, file: StaticString = #filePath, line: UInt = #line) {
+    XCTAssertNil(VC.launchedWorkflows.last, "workflow found when none expected", file: file, line: line)
 }
 #endif
 #endif

--- a/Sources/SwiftCurrent_Testing/CustomAssertions.swift
+++ b/Sources/SwiftCurrent_Testing/CustomAssertions.swift
@@ -18,7 +18,16 @@ import UIKit
 #if !os(watchOS)
 /// Assert that a workflow was launched and matches the workflow passed in
 public func XCTAssertWorkflowLaunched<F>(from VC: UIViewController, workflow: Workflow<F>, file: StaticString = #filePath, line: UInt = #line) {
+    XCTAssertWorkflowLaunched(from: VC, workflow: AnyWorkflow(workflow), file: file, line: line)
+}
+
+/// Assert that a workflow was launched and matches the workflow passed in
+public func XCTAssertWorkflowLaunched(from VC: UIViewController, workflow: AnyWorkflow?, file: StaticString = #filePath, line: UInt = #line) {
     let last = VC.launchedWorkflows.last
+    guard let workflow = workflow else {
+        XCTAssertNil(last, "workflow found when none expected", file: file, line: line)
+        return
+    }
     XCTAssertNotNil(last, "No workflow found", file: file, line: line)
     guard let listenerWorkflow = last,
           listenerWorkflow.count == workflow.count else {


### PR DESCRIPTION
<!-- All PRs should have some kind of issue backing them. This means the community has had some opportunity to contribute ideas, or that the PR is fixing a problem that is being tracked -->
### Linked Issue: 

<!-- (See our contributing guidelines for more details) -->

<!-- Please remove any items below that may not apply to your Pull Request -->
## Checklist:
- [x] Did you sign the [Contributor License Agreement](https://cla-assistant.io/wwt/SwiftCurrent)?
- [x] Is the linter reporting 0 errors?
- [x] Did you comply with our [styleguide](https://github.com/wwt/SwiftCurrent/blob/main/.github/STYLEGUIDE.md)?
- [x] Is there [adequate test coverage](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#test-etiquette) for your new code?
- [ ] Does the CI pipeline pass?
- [ ] Did you [update the documentation](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#documentation)?
- [ ] Did you [update the sample app](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#sample-app)?
- [ ] Do we need to [increment the minor/major version](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#versioning)?
- [x] Did you [change the public API](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#public-api)?
- [x] Have you done everything you can to make sure that errors that can occur are compile-time errors, and if they have to be runtime do you have adequate tests and documentation around those runtime errors? [For more details](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#errors).

----

### If Applicable:
- [ ] Did you test when the first item is skipped?
- [ ] Did you test when the last item is skipped?
- [ ] Did you test when middle items are skipped?
- [ ] Did you test when incorrect data is passed forward?
- [ ] Did you test proceeding backwards?

----

### If Public API Has Changed:
- [ ] Did you deprecate (rather than remove) any old methods/variables/etc? [Our philosophy for deprecation](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#deprecation).
- [ ] Have you done the best that you can to make sure that the compiler guides people to changing to the new API? (Example: the renamed attribute)
- [ ] If necessary, have you tested the upgrade path for at least N-1 versions? For example, if data persists between v1 and v2 then that upgrade should be tested and as easy as we can make it.
