### PR TITLE
Add the ability to abandon workflow when a publisher emits a value

### DIFF
--- a/Sources/SwiftCurrent_SwiftUI/Views/WorkflowView.swift
+++ b/Sources/SwiftCurrent_SwiftUI/Views/WorkflowView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 WWT and Tyler Thompson. All rights reserved.
 //  
 
+import Combine
 import SwiftUI
 import SwiftCurrent
 
@@ -200,6 +201,11 @@ public struct WorkflowView<Content: View>: View {
     /// Adds an action to perform when this `Workflow` has abandoned.
     public func onAbandon<WI: _WorkflowItemProtocol>(_ closure: @escaping () -> Void) -> Self where Content == WorkflowLauncher<WI> {
         Self(self, newContent: _content.wrappedValue.onAbandon(closure: closure))
+    }
+
+    /// Subscribers to a combine publisher, when a value is emitted the workflow will abandon.
+    public func abandonOn<WI: _WorkflowItemProtocol, P: Publisher>(_ publisher: P) -> Self where Content == WorkflowLauncher<WI>, P.Failure == Never {
+        Self(self, newContent: _content.wrappedValue.abandonOn(publisher))
     }
 
     /// Wraps content in a NavigationView.


### PR DESCRIPTION
<!-- All PRs should have some kind of issue backing them. This means the community has had some opportunity to contribute ideas, or that the PR is fixing a problem that is being tracked -->
### Linked Issue: Closes #95

<!-- (See our contributing guidelines for more details) -->

<!-- Please remove any items below that may not apply to your Pull Request -->
## Checklist:
- [x] Did you sign the [Contributor License Agreement](https://cla-assistant.io/wwt/SwiftCurrent)?
- [x] Is the linter reporting 0 errors?
- [x] Did you comply with our [styleguide](https://github.com/wwt/SwiftCurrent/blob/main/.github/STYLEGUIDE.md)?
- [x] Is there [adequate test coverage](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#test-etiquette) for your new code?
- [x] Does the CI pipeline pass?
- [x] Did you [update the documentation](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#documentation)?
- [x] Did you [change the public API](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#public-api)?
- [x] Have you done everything you can to make sure that errors that can occur are compile-time errors, and if they have to be runtime do you have adequate tests and documentation around those runtime errors? [For more details](https://github.com/wwt/SwiftCurrent/blob/main/.github/CONTRIBUTING.md#errors).